### PR TITLE
Added pagination support for numbered pages (NangoHQ/nango-sync#16)

### DIFF
--- a/packages/core/db/migrations/20230209120503_add_paging_number_request_path.cjs
+++ b/packages/core/db/migrations/20230209120503_add_paging_number_request_path.cjs
@@ -1,0 +1,11 @@
+exports.up = function (knex, _) {
+    return knex.schema.withSchema('nango').alterTable('_nango_syncs', function (table) {
+        table.string('paging_number_request_path');
+    });
+};
+
+exports.down = function (knex, _) {
+    return knex.schema.withSchema('nango').alterTable('_nango_syncs', function (table) {
+        table.dropColumn('paging_number_request_path');
+    });
+};

--- a/packages/core/lib/sync.model.ts
+++ b/packages/core/lib/sync.model.ts
@@ -17,6 +17,7 @@ export interface Sync {
     paging_offset_request_path?: string;
     paging_limit_request_path?: string;
     paging_limit?: number;
+    paging_number_request_path?: string;
     auto_mapping: boolean;
     mapped_table?: string;
     frequency?: number;

--- a/packages/node-client/lib/nango.ts
+++ b/packages/node-client/lib/nango.ts
@@ -23,6 +23,7 @@ export interface NangoSyncConfig {
     paging_offset_request_path?: string;
     paging_limit_request_path?: string;
     paging_limit?: number;
+    paging_number_request_path?: string;
     auto_mapping?: boolean;
     mapped_table?: string;
     frequency?: string;
@@ -60,6 +61,7 @@ export class Nango {
             paging_header_link_rel: config.paging_header_link_rel,
             paging_offset_request_path: config.paging_offset_request_path,
             paging_limit_request_path: config.paging_limit_request_path,
+            paging_number_request_path: config.paging_number_request_path,
             paging_limit: config.paging_limit,
             auto_mapping: config.auto_mapping,
             mapped_table: config.mapped_table,

--- a/packages/server/lib/syncs.controller.ts
+++ b/packages/server/lib/syncs.controller.ts
@@ -21,6 +21,7 @@ class SyncsController {
             paging_offset_request_path: req.body['paging_offset_request_path'],
             paging_limit_request_path: req.body['paging_limit_request_path'],
             paging_limit: req.body['paging_limit'],
+            paging_number_request_path: req.body['paging_number_request_path'],
             auto_mapping: req.body['auto_mapping'] || true, // Default to auto mapping enabled.
             mapped_table: req.body['mapped_table'],
             frequency: req.body['frequency'],

--- a/packages/worker/lib/services/external.service.ts
+++ b/packages/worker/lib/services/external.service.ts
@@ -56,6 +56,16 @@ class ExternalService {
                 }
             }
 
+            //  Fetching subsequent page (param in URL)
+            if (sync.paging_number_request_path != null) {
+                if (['get', 'delete'].includes(sync.method)) {
+                    // TODO add first page number? (0 or 1)
+                    config.params[sync.paging_number_request_path] = page;
+                } else if (['post', 'put', 'patch'].includes(sync.method)) {
+                    sync.body[sync.paging_number_request_path] = page;
+                }
+            }
+
             logger.debug(
                 `(Sync ID: ${sync.id}) Fetching page ${page} with url ${syncWithAuth.url} (method: ${JSON.stringify(sync.method)}). Header: ${JSON.stringify(
                     config.headers
@@ -138,6 +148,16 @@ class ExternalService {
             if (sync.paging_offset_request_path != null && sync.paging_limit_request_path != null && sync.paging_limit != null) {
                 if (newResults.length > 0) {
                     offset += newResults.length;
+                    continue;
+                } else {
+                    // The last page was empty, so we should not count it.
+                    page -= 1;
+                }
+            }
+
+            if (sync.paging_number_request_path != null) {
+                // TODO check for page_number_end?
+                if (newResults.length > 0) {
                     continue;
                 } else {
                     // The last page was empty, so we should not count it.


### PR DESCRIPTION
I've implemented numbered page pagination (NangoHQ/nango-sync#16) for our own needs to synchronise with the FreshSales API.

I've left two TODO comments in the code for potential additional parameters that might be needed for other APIs.

Let me know if this can be merged into your codebase or if there is something else I need to do.